### PR TITLE
return PDF path directly

### DIFF
--- a/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
+++ b/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
@@ -158,8 +158,6 @@ public class SwiftyTesseract {
     var pixImage: Pix
     
     defer {
-      // Release the Pix instance from memory
-      pixDestroy(&pixImage)
       semaphore.signal()
     }
 
@@ -168,6 +166,10 @@ public class SwiftyTesseract {
     } catch {
       completionHandler(nil)
       return
+    }
+    defer {
+      // Release the Pix instance from memory
+      pixDestroy(&pixImage)
     }
 
     TessBaseAPISetImage2(tesseract, pixImage)


### PR DESCRIPTION
Hey @Steven0351,

while creating the new version of [PDF Archiver](http://github.com/pdf-Archiver/pdf-archive-viewer) I figured out a strange behaviour in the writing/loading of a PDF document with OCR content.

tl;dr: I wrote one more API function von SwiftyTesseract that returns the path of the created PDF directly. Could you have a look at it? 🙂 