### PR TITLE
Update CocoaPods installation of Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,7 @@ The bundle parameter is required to locate the `tessdata` folder. This will only
 use_frameworks!
 
 target 'YOUR_TARGET_NAME' do
-    pod 'SwiftyTesseract',    '~> 2.0'
+    pod 'SwiftyTesseract',    '~> 2.2.2'
 end
 
 post_install do |installer|

--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ The bundle parameter is required to locate the `tessdata` folder. This will only
 # Installation
 ### [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html)
 
-**Tested with `pod --version`: `1.3.1`**
+**Tested with `pod --version`: `1.8.4`**
 
 ```ruby
 # Podfile
@@ -45,6 +45,16 @@ use_frameworks!
 
 target 'YOUR_TARGET_NAME' do
     pod 'SwiftyTesseract',    '~> 2.0'
+end
+
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        if target.name == 'SwiftyTesseract'
+            target.build_configurations.each do |config|
+                config.build_settings['SWIFT_VERSION'] = '4.2'
+            end
+        end
+    end
 end
 ```
 


### PR DESCRIPTION
CocoaPods unfortunately doesn't have the capability to use different Swift versions.
Add Podfile code to readme to make sure the project works on new Swift 5 projects.
Otherwise the workspace will incorrectly recognise the SwiftyTesseract as a Swift 5 project, and not build.
This will make sure the project uses Swift 4.2.
Source: https://stackoverflow.com/a/46690240/7172627