### PR TITLE
Added block iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+.DS_Store

--- a/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
+++ b/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		62E3D1E22049FAAE0030AB11 /* IMG_1108.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */; };
 		8703EC8222032A54005B03EA /* MultipleInterwordSpaces.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */; };
 		8705C26E222ED10D0014DCAA /* NormalAndSmallFonts.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */; };
+		9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = IMG_1108.jpg; sourceTree = "<group>"; };
 		8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = MultipleInterwordSpaces.jpg; sourceTree = "<group>"; };
 		8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = NormalAndSmallFonts.jpg; sourceTree = "<group>"; };
+		9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageModelDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				621E38542097A09000446A42 /* LanguageStringConverter.swift */,
+				9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				62DF38BC2066AC01008F0476 /* RecognitionLanguage.swift in Sources */,
 				62DF38BB2066AC01008F0476 /* TesseractVariableName.swift in Sources */,
 				6271A4C92047A360005DB23B /* SwiftyTesseract.swift in Sources */,
+				9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */,
 				62DF38BA2066AC01008F0476 /* EngineMode.swift in Sources */,
 				621E38552097A09000446A42 /* LanguageStringConverter.swift in Sources */,
 				62DF38BF2066AC2A008F0476 /* String+Extensions.swift in Sources */,

--- a/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
+++ b/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		62E3D1E22049FAAE0030AB11 /* IMG_1108.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */; };
 		8703EC8222032A54005B03EA /* MultipleInterwordSpaces.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */; };
 		8705C26E222ED10D0014DCAA /* NormalAndSmallFonts.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */; };
+		9D0C4C22244C2FF500270FA0 /* RecognizedBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C4C21244C2FF500270FA0 /* RecognizedBlock.swift */; };
+		9D0C4C24244C300F00270FA0 /* ResultIteratorLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C4C23244C300F00270FA0 /* ResultIteratorLevel.swift */; };
 		9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */; };
 /* End PBXBuildFile section */
 
@@ -92,6 +94,8 @@
 		62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = IMG_1108.jpg; sourceTree = "<group>"; };
 		8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = MultipleInterwordSpaces.jpg; sourceTree = "<group>"; };
 		8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = NormalAndSmallFonts.jpg; sourceTree = "<group>"; };
+		9D0C4C21244C2FF500270FA0 /* RecognizedBlock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecognizedBlock.swift; sourceTree = "<group>"; };
+		9D0C4C23244C300F00270FA0 /* ResultIteratorLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultIteratorLevel.swift; sourceTree = "<group>"; };
 		9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageModelDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -197,6 +201,7 @@
 		6271A3D62047A0D7005DB23B /* SwiftyTesseract */ = {
 			isa = PBXGroup;
 			children = (
+				9D5C241C244A108100D66FFE /* Structs */,
 				6255DACD2159CEF400A52189 /* dependencies */,
 				62DF38B42066ABE9008F0476 /* Extensions */,
 				62DF38B32066ABE0008F0476 /* Enums */,
@@ -241,6 +246,7 @@
 				62DF38B82066AC01008F0476 /* RecognitionLanguage.swift */,
 				62DF38B52066AC00008F0476 /* SwiftyTesseractError.swift */,
 				62DF38B72066AC01008F0476 /* TesseractVariableName.swift */,
+				9D0C4C23244C300F00270FA0 /* ResultIteratorLevel.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -252,6 +258,14 @@
 				62DF38BD2066AC2A008F0476 /* String+Extensions.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		9D5C241C244A108100D66FFE /* Structs */ = {
+			isa = PBXGroup;
+			children = (
+				9D0C4C21244C2FF500270FA0 /* RecognizedBlock.swift */,
+			);
+			path = Structs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -405,8 +419,10 @@
 				62DF38BA2066AC01008F0476 /* EngineMode.swift in Sources */,
 				621E38552097A09000446A42 /* LanguageStringConverter.swift in Sources */,
 				62DF38BF2066AC2A008F0476 /* String+Extensions.swift in Sources */,
+				9D0C4C24244C300F00270FA0 /* ResultIteratorLevel.swift in Sources */,
 				62DF38B92066AC01008F0476 /* SwiftyTesseractError.swift in Sources */,
 				62DF38C02066AC2A008F0476 /* Bundle+pathToTrainedData.swift in Sources */,
+				9D0C4C22244C2FF500270FA0 /* RecognizedBlock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
+++ b/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		8705C26E222ED10D0014DCAA /* NormalAndSmallFonts.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */; };
 		9D0C4C22244C2FF500270FA0 /* RecognizedBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C4C21244C2FF500270FA0 /* RecognizedBlock.swift */; };
 		9D0C4C24244C300F00270FA0 /* ResultIteratorLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C4C23244C300F00270FA0 /* ResultIteratorLevel.swift */; };
+		9D0C4C26244CA0B700270FA0 /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C4C25244CA0B700270FA0 /* BoundingBox.swift */; };
 		9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */; };
 /* End PBXBuildFile section */
 
@@ -96,6 +97,7 @@
 		8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = NormalAndSmallFonts.jpg; sourceTree = "<group>"; };
 		9D0C4C21244C2FF500270FA0 /* RecognizedBlock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecognizedBlock.swift; sourceTree = "<group>"; };
 		9D0C4C23244C300F00270FA0 /* ResultIteratorLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultIteratorLevel.swift; sourceTree = "<group>"; };
+		9D0C4C25244CA0B700270FA0 /* BoundingBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingBox.swift; sourceTree = "<group>"; };
 		9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageModelDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -264,6 +266,7 @@
 			isa = PBXGroup;
 			children = (
 				9D0C4C21244C2FF500270FA0 /* RecognizedBlock.swift */,
+				9D0C4C25244CA0B700270FA0 /* BoundingBox.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 				62DF38BC2066AC01008F0476 /* RecognitionLanguage.swift in Sources */,
 				62DF38BB2066AC01008F0476 /* TesseractVariableName.swift in Sources */,
 				6271A4C92047A360005DB23B /* SwiftyTesseract.swift in Sources */,
+				9D0C4C26244CA0B700270FA0 /* BoundingBox.swift in Sources */,
 				9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */,
 				62DF38BA2066AC01008F0476 /* EngineMode.swift in Sources */,
 				621E38552097A09000446A42 /* LanguageStringConverter.swift in Sources */,

--- a/SwiftyTesseract/SwiftyTesseract/Enums/ResultIteratorLevel.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Enums/ResultIteratorLevel.swift
@@ -1,0 +1,28 @@
+//
+//  TesseractResultIteratorLevel.swift
+//  SwiftyTesseract
+//
+//  Created by Antonio Zaitoun on 17/04/2020.
+//  Copyright © 2020 Steven Sherry. All rights reserved.
+//
+
+import Foundation
+import libtesseract
+
+public enum ResultIteratorLevel: TessPageIteratorLevel.RawValue{
+  /// RIL_BLOCK
+  case block
+  /// RIL_PARA
+  case paragraph
+  /// RIL_TEXTLINE
+  case textline
+  /// RIL_WORD
+  case word
+  /// RIL_SYMBOL
+  case symbol
+
+  public var tesseractLevel: TessPageIteratorLevel {
+    return TessPageIteratorLevel(rawValue: self.rawValue)
+  }
+}
+

--- a/SwiftyTesseract/SwiftyTesseract/Enums/SwiftyTesseractError.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Enums/SwiftyTesseractError.swift
@@ -14,6 +14,7 @@ extension SwiftyTesseract {
     case unableToBeginDocument
     case unableToProcessPage
     case unableToEndDocument
+    case unableToRetrieveIterator
     
     static let noLanguagesErrorMessage = "SwiftyTesseract must be initialized with at least one language"
     static let initializationErrorMessage = "Initialization of SwiftyTesseract has failed. " +

--- a/SwiftyTesseract/SwiftyTesseract/Extensions/Bundle+pathToTrainedData.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Extensions/Bundle+pathToTrainedData.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-extension Bundle {
-  var pathToTrainedData: String {
+extension Bundle: LanguageModelDataSource {
+  public var pathToTrainedData: String {
     return bundleURL.appendingPathComponent("tessdata").path
   }
 }

--- a/SwiftyTesseract/SwiftyTesseract/Protocols/LanguageModelDataSource.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Protocols/LanguageModelDataSource.swift
@@ -1,0 +1,13 @@
+//
+//  LanguageModelDataSource.swift
+//  SwiftyTesseract
+//
+//  Created by Antonio Zaitoun on 17/04/2020.
+//  Copyright © 2020 Steven Sherry. All rights reserved.
+//
+
+import Foundation
+
+public protocol LanguageModelDataSource {
+  var pathToTrainedData: String { get }
+}

--- a/SwiftyTesseract/SwiftyTesseract/Structs/BoundingBox.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Structs/BoundingBox.swift
@@ -1,0 +1,25 @@
+//
+//  BoundingBox.swift
+//  SwiftyTesseract
+//
+//  Created by Antonio Zaitoun on 19/04/2020.
+//  Copyright © 2020 Steven Sherry. All rights reserved.
+//
+
+import Foundation
+
+struct BoundingBox {
+  var x1: Int32 = 0
+  var x2: Int32 = 0
+  var y1: Int32 = 0
+  var y2: Int32 = 0
+
+  var cgRect: CGRect {
+    return CGRect(
+      x: .init(x1),
+      y: .init(y1),
+      width: .init(x2 - x1),
+      height: .init(y2 - y1)
+    )
+  }
+}

--- a/SwiftyTesseract/SwiftyTesseract/Structs/RecognizedBlock.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Structs/RecognizedBlock.swift
@@ -1,0 +1,15 @@
+//
+//  RecognizedBlock.swift
+//  SwiftyTesseract
+//
+//  Created by Antonio Zaitoun on 17/04/2020.
+//  Copyright © 2020 Steven Sherry. All rights reserved.
+//
+
+import Foundation
+
+public struct RecognizedBlock {
+  public var text: String
+  public var boundingBox: CGRect
+  public var confidance: Float
+}

--- a/SwiftyTesseract/SwiftyTesseract/Structs/RecognizedBlock.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Structs/RecognizedBlock.swift
@@ -11,5 +11,5 @@ import Foundation
 public struct RecognizedBlock {
   public var text: String
   public var boundingBox: CGRect
-  public var confidance: Float
+  public var confidence: Float
 }

--- a/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
+++ b/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
@@ -317,24 +317,16 @@ public class SwiftyTesseract {
     guard let cString = TessResultIteratorGetUTF8Text(iterator, level) else { return nil }
     defer { TessDeleteText(cString) }
 
-    var x1: Int32 = 0
-    var y1: Int32 = 0
-    var x2: Int32 = 0
-    var y2: Int32 = 0
-    TessPageIteratorBoundingBox(iterator, level, &x1, &y1, &x2, &y2)
-
-    let x = CGFloat(x1)
-    let y = CGFloat(y1)
-    let width = CGFloat(x2 - x1)
-    let height = CGFloat(y2 - y1)
+    var boundingBox = BoundingBox()
+    TessPageIteratorBoundingBox(iterator, level, &boundingBox.x1, &boundingBox.y1, &boundingBox.x2, &boundingBox.y2)
 
     //TODO: normalizations?
 
     let text = String(cString: cString)
-    let rect = CGRect(x: x, y: y, width: width, height: height)
+    let rect = boundingBox.cgRect
     let confidence = TessResultIteratorConfidence(iterator, level)
 
-    return RecognizedBlock(text: text, boundingBox: rect, confidance: confidence)
+    return RecognizedBlock(text: text, boundingBox: rect, confidence: confidence)
   }
 }
 

--- a/SwiftyTesseract/SwiftyTesseractTests/SwiftyTesseractTests.swift
+++ b/SwiftyTesseract/SwiftyTesseractTests/SwiftyTesseractTests.swift
@@ -44,6 +44,20 @@ class SwiftyTesseractTests: XCTestCase {
     XCTAssertEqual(answer, string.trimmingCharacters(in: .whitespacesAndNewlines))
     
   }
+
+  func testBlockIterator() {
+    let image = getImage(named: "image_sample.jpg")
+    let answer = "1234567890"
+
+    guard case .success(_) = swiftyTesseract.performOCR(on: image) else { return XCTFail("OCR was unsuccessful") }
+    guard case .success(let blocks) = swiftyTesseract.recognizedBlocksByLevel(.symbol) else { return XCTFail("Failed getting iterator") }
+    XCTAssertEqual(answer.count, blocks.count)
+
+
+    guard case .success(let wordBlocks) = swiftyTesseract.recognizedBlocksByLevel(.word) else { return XCTFail("Failed getting iterator") }
+    XCTAssertEqual(1, wordBlocks.count)
+    XCTAssertEqual(answer, wordBlocks.first!.text)
+  }
   
   func testRealImage() {
     let image = getImage(named: "IMG_1108.jpg")


### PR DESCRIPTION
I noticed that the block iterator is missing from the wrapper so I decided to add that implementation. The code I wrote is based on the https://github.com/gali8/Tesseract-OCR-iOS Objective-C implementation.

This additional functionality will allow developers to locate the words on the image (for drawing purposes or NLP)

## Code Change
- Added ResultIteratorLevel enum.
- Added RecognizedBlock struct.
- Added (public) recognizedBlocksByLevel(_:)
- Added (private) blockFromIterator

## Tests
- Added testBlockIterator (Passing)