### PR TITLE
Added support to load Tesseract Data from any location.

### DIFF
--- a/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
+++ b/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		62E3D1E22049FAAE0030AB11 /* IMG_1108.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */; };
 		8703EC8222032A54005B03EA /* MultipleInterwordSpaces.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */; };
 		8705C26E222ED10D0014DCAA /* NormalAndSmallFonts.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */; };
+		9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = IMG_1108.jpg; sourceTree = "<group>"; };
 		8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = MultipleInterwordSpaces.jpg; sourceTree = "<group>"; };
 		8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = NormalAndSmallFonts.jpg; sourceTree = "<group>"; };
+		9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageModelDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				621E38542097A09000446A42 /* LanguageStringConverter.swift */,
+				9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				62DF38BC2066AC01008F0476 /* RecognitionLanguage.swift in Sources */,
 				62DF38BB2066AC01008F0476 /* TesseractVariableName.swift in Sources */,
 				6271A4C92047A360005DB23B /* SwiftyTesseract.swift in Sources */,
+				9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */,
 				62DF38BA2066AC01008F0476 /* EngineMode.swift in Sources */,
 				621E38552097A09000446A42 /* LanguageStringConverter.swift in Sources */,
 				62DF38BF2066AC2A008F0476 /* String+Extensions.swift in Sources */,

--- a/SwiftyTesseract/SwiftyTesseract/Extensions/Bundle+pathToTrainedData.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Extensions/Bundle+pathToTrainedData.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-extension Bundle {
-  var pathToTrainedData: String {
+extension Bundle: LanguageModelDataSource {
+  public var pathToTrainedData: String {
     return bundleURL.appendingPathComponent("tessdata").path
   }
 }

--- a/SwiftyTesseract/SwiftyTesseract/Protocols/LanguageModelDataSource.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Protocols/LanguageModelDataSource.swift
@@ -1,0 +1,13 @@
+//
+//  LanguageModelDataSource.swift
+//  SwiftyTesseract
+//
+//  Created by Antonio Zaitoun on 17/04/2020.
+//  Copyright © 2020 Steven Sherry. All rights reserved.
+//
+
+import Foundation
+
+public protocol LanguageModelDataSource {
+  var pathToTrainedData: String { get }
+}

--- a/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
+++ b/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
@@ -137,6 +137,22 @@ public class SwiftyTesseract {
     
     self.init(languages: [language], dataSource: dataSource, engineMode: engineMode)
   }
+
+  @available(*, deprecated, message: "migrate to init(language:dataSource:engineMode:)")
+  public convenience init(language: RecognitionLanguage,
+                          bundle: LanguageModelDataSource = Bundle.main,
+                          engineMode: EngineMode = .lstmOnly) {
+    self.init(language: language, dataSource: bundle, engineMode: engineMode)
+  }
+
+  @available(*, deprecated, message: "migrate to init(languages:dataSource:engineMode:)")
+  public convenience init(languages: [RecognitionLanguage],
+                            bundle: LanguageModelDataSource = Bundle.main,
+                            engineMode: EngineMode = .lstmOnly) {
+        self.init(languages: languages, dataSource: bundle, engineMode: engineMode)
+  }
+
+
   
   deinit {
     // Releases the tesseract instance from memory

--- a/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
+++ b/SwiftyTesseract/SwiftyTesseract/SwiftyTesseract.swift
@@ -19,8 +19,8 @@ public class SwiftyTesseract {
   
   // MARK: - Properties
   private let tesseract: TessBaseAPI = TessBaseAPICreate()
-    
-  private let bundle: Bundle
+
+  private let dataSource: LanguageModelDataSource
   
   /// Required to make `performOCR(on:completionHandler:)` thread safe. Runs faster on average than a `DispatchQueue` with `.barrier` flag.
   private let semaphore = DispatchSemaphore(value: 1)
@@ -88,19 +88,19 @@ public class SwiftyTesseract {
   }()
   
   private init(languageString: String,
-               bundle: Bundle = .main,
+               dataSource: LanguageModelDataSource = Bundle.main,
                engineMode: EngineMode = .lstmOnly) {
     
     // save input bundle
-    self.bundle = bundle
+    self.dataSource = dataSource
     
-    setEnvironmentVariable(.tessDataPrefix, value: bundle.pathToTrainedData)
+    setEnvironmentVariable(.tessDataPrefix, value: dataSource.pathToTrainedData)
     
     // This variable's value somehow persists between deinit and init, default value should be set
     setTesseractVariable(.oldCharacterHeight, value: "0")
     
     guard TessBaseAPIInit2(tesseract,
-                           bundle.pathToTrainedData,
+                           dataSource.pathToTrainedData,
                            languageString,
                            TessOcrEngineMode(rawValue: engineMode.rawValue)) == 0
     else { fatalError(SwiftyTesseract.Error.initializationErrorMessage) }
@@ -117,11 +117,11 @@ public class SwiftyTesseract {
   ///   - bundle: The bundle that contains the tessdata folder - default is .main
   ///   - engineMode: The tesseract engine mode - default is .lstmOnly
   public convenience init(languages: [RecognitionLanguage],
-              bundle: Bundle = .main,
+              dataSource: LanguageModelDataSource = Bundle.main,
               engineMode: EngineMode = .lstmOnly) {
     
     let stringLanguages = RecognitionLanguage.createLanguageString(from: languages)
-    self.init(languageString: stringLanguages, bundle: bundle, engineMode: engineMode)
+    self.init(languageString: stringLanguages, dataSource: dataSource, engineMode: engineMode)
   }
   
   /// Convenience initializer for creating an instance of SwiftyTesseract with one language to avoid having to
@@ -132,10 +132,10 @@ public class SwiftyTesseract {
   ///   - bundle: The bundle that contains the tessdata folder - default is .main
   ///   - engineMode: The tesseract engine mode - default is .lstmOnly
   public convenience init(language: RecognitionLanguage,
-                          bundle: Bundle = .main,
+                          dataSource: LanguageModelDataSource = Bundle.main,
                           engineMode: EngineMode = .lstmOnly) {
     
-    self.init(languages: [language], bundle: bundle, engineMode: engineMode)
+    self.init(languages: [language], dataSource: dataSource, engineMode: engineMode)
   }
   
   deinit {
@@ -269,7 +269,7 @@ public class SwiftyTesseract {
   }
   
   private func makeRenderer(at url: URL) throws -> OpaquePointer {
-    guard let renderer = TessPDFRendererCreate(url.path, bundle.pathToTrainedData, 0) else {
+    guard let renderer = TessPDFRendererCreate(url.path, self.dataSource.pathToTrainedData, 0) else {
       throw SwiftyTesseract.Error.unableToCreateRenderer
     }
     

--- a/SwiftyTesseract/SwiftyTesseractTests/SwiftyTesseractTests.swift
+++ b/SwiftyTesseract/SwiftyTesseractTests/SwiftyTesseractTests.swift
@@ -200,7 +200,7 @@ class SwiftyTesseractTests: XCTestCase {
     guard let documentsFolder = try? FileManager.default.url(for: .documentDirectory,
                                                          in: .userDomainMask,
                                                          appropriateFor: nil,
-                                                         create: false) else { XCTAssert(false); return; }
+                                                         create: false) else { return XCTFail() }
     // this directory will contain our traineddata and is what we will pass to the data source
     let tessData = documentsFolder.appendingPathComponent("tessdata")
 

--- a/SwiftyTesseract/SwiftyTesseractTests/SwiftyTesseractTests.swift
+++ b/SwiftyTesseract/SwiftyTesseractTests/SwiftyTesseractTests.swift
@@ -21,7 +21,7 @@ class SwiftyTesseractTests: XCTestCase {
   override func setUp() {
     super.setUp()
     bundle = Bundle(for: self.classForCoder)
-    swiftyTesseract = SwiftyTesseract(language: .english, bundle: bundle)
+    swiftyTesseract = SwiftyTesseract(language: .english, dataSource: bundle)
     cancellables = Set()
   }
   
@@ -70,7 +70,7 @@ class SwiftyTesseractTests: XCTestCase {
   }
     
   func testMultipleSpacesImage_withPreserveMultipleSpaces() {
-    swiftyTesseract = SwiftyTesseract(language: .english, bundle: bundle, engineMode: .tesseractOnly)
+    swiftyTesseract = SwiftyTesseract(language: .english, dataSource: bundle, engineMode: .tesseractOnly)
     swiftyTesseract.preserveInterwordSpaces = true
     let image = getImage(named: "MultipleInterwordSpaces.jpg")
     
@@ -87,7 +87,7 @@ class SwiftyTesseractTests: XCTestCase {
   }
   
   func testMultipleLanguages() {
-    swiftyTesseract = SwiftyTesseract(languages: [.english, .french], bundle: bundle, engineMode: .tesseractOnly)
+    swiftyTesseract = SwiftyTesseract(languages: [.english, .french], dataSource: bundle, engineMode: .tesseractOnly)
     let answer = """
     Lenore
     Lenore, Lenore, mon amour
@@ -115,7 +115,7 @@ class SwiftyTesseractTests: XCTestCase {
   
   func testWithCustomLanguage() {
     let image = getImage(named: "MVRCode3.png")
-    swiftyTesseract = SwiftyTesseract(language: .custom("OCRB"), bundle: bundle, engineMode: .tesseractOnly)
+    swiftyTesseract = SwiftyTesseract(language: .custom("OCRB"), dataSource: bundle, engineMode: .tesseractOnly)
     let answer = """
     P<GRCELLINAS<<GEORGIOS<<<<<<<<<<<<<<<<<<<<<<
     AE00000057GRC6504049M1208283<<<<<<<<<<<<<<00
@@ -127,7 +127,7 @@ class SwiftyTesseractTests: XCTestCase {
   
   func testLoadingStandardAndCustomLanguages() {
     // This test would otherwise crash if it was unable to load both languages
-    swiftyTesseract = SwiftyTesseract(languages: [.custom("OCRB"), .english], bundle: bundle)
+    swiftyTesseract = SwiftyTesseract(languages: [.custom("OCRB"), .english], dataSource: bundle)
   }
   
   // This really more or less exists purely to show how to perform OCR on a background thread
@@ -193,6 +193,39 @@ class SwiftyTesseractTests: XCTestCase {
     let document = PDFDocument(data: data)
     XCTAssertNotNil(document)
     XCTAssertTrue(document?.string?.contains("1234567890") ?? false)
+  }
+
+  func testDataSourceFromFiles() {
+    // Move data from bundle to documents directory /tessdata
+    guard let documentsFolder = try? FileManager.default.url(for: .documentDirectory,
+                                                         in: .userDomainMask,
+                                                         appropriateFor: nil,
+                                                         create: false) else { XCTAssert(false); return; }
+    // this directory will contain our traineddata and is what we will pass to the data source
+    let tessData = documentsFolder.appendingPathComponent("tessdata")
+
+    try? FileManager.default.createDirectory(at: tessData, withIntermediateDirectories: true, attributes: nil)
+    if let path = bundle.url(forResource: "eng", withExtension: "traineddata", subdirectory: "tessdata") {
+        try? FileManager.default.copyItem(at: path, to: tessData.appendingPathComponent("eng.traineddata"))
+    }
+
+    // setup the data source class
+    struct MyDataSource: LanguageModelDataSource {
+        var location: String
+        var pathToTrainedData: String { return location }
+    }
+
+    let dataSource = MyDataSource(location: tessData.path)
+
+    // init the wrapper class using our custom data source.
+    let swt = SwiftyTesseract(language: .english, dataSource: dataSource)
+
+    // test it
+    let image = getImage(named: "IMG_1108.jpg")
+    let answer = "2F.SM.LC.SCA.12FT"
+
+    guard case let .success(string) = swt.performOCR(on: image) else { return XCTFail("OCR was unsuccessful") }
+    XCTAssertEqual(answer, string.trimmingCharacters(in: .whitespacesAndNewlines))
   }
   
   func getImage(named name: String) -> UIImage {


### PR DESCRIPTION
## Code

- Replace parameter name in initializer from `bundle` to `dataSource`.
- Removed any use of `Bundle` and replaced it with `LanguageModelDataSource`.

## Tests
- Added a unit test which copies the english trained data from the bundle into the documents directory under /tessdata. Then creates a SwiftyTesseract instance using a data source which uses the documents directory location.

Closes #55 