### PR TITLE
fix Ambiguous use of init(_:) after upgrading to iOS 14

### DIFF
--- a/SwiftyTesseract/SwiftyTesseract/Structs/BoundingBox.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Structs/BoundingBox.swift
@@ -16,7 +16,7 @@ struct BoundingBox {
 
   var cgRect: CGRect {
     return CGRect(
-      x: .init(originX),
+      x: Int(originX),
       y: .init(originY),
       width: .init(widthOffset - originX),
       height: .init(heightOffset - originY)


### PR DESCRIPTION
<!-- Thanks for contributing to SwiftyTesseract! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run the tests to ensure I have not created any regressions
- [x] I've added new tests for new functionality if neccessary.
- [x] I've updated the documentation if necessary.
- [x] I've read the [Contribution Guidelines](https://github.com/SwiftyTesseract/SwiftyTesseract/blob/master/CONTRIBUTING.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This change solves an ambiguous init call for the BoundingBox CGRect struct parameter type and was encountered after upgrading to iOS 14

### Description
<!-- Describe your changes in detail. -->
I have specified the desired type of BoundingBox.cgRect variable initialisation parameters to help Swift determine which CGRect initializer should be used

<!-- Please describe in detail how you tested your changes. -->
scanning various document such as passport with an implementation of Swifty Tesseract and by making sure that the correct type was an Int

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->

The easiest way is to quickly implement a document scanning library such as QMRZScanner and try to scan a document.
It's a pretty high level test for such a small change as such, it should be more than enough.

<!-- Providing these will reduce the time needed for testing and review. -->