### PR TITLE
Typo in Linux installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/SwiftyTesseract/SwiftyTesseract.git", .upToNextMajor(from: "4.0.0")
+    .package(url: "https://github.com/SwiftyTesseract/SwiftyTesseract.git", .upToNextMajor(from: "4.0.0"))
   ],
   targets: [
     .target(


### PR DESCRIPTION
Fixed typo in the Linux installation guide.

### Checklist
- [x] I've run the tests to ensure I have not created any regressions
- [x] I've added new tests for new functionality if neccessary.
- [x] I've updated the documentation if necessary.
- [x] I've read the [Contribution Guidelines](https://github.com/SwiftyTesseract/SwiftyTesseract/blob/develop/CONTRIBUTING.md)

### Motivation and Context
 Typo.
