### PR TITLE
Rename @_functionBuilder to @resultBuilder

### DIFF
--- a/Sources/SwiftyTesseract/Tesseract+ConfigurationBuilder.swift
+++ b/Sources/SwiftyTesseract/Tesseract+ConfigurationBuilder.swift
@@ -9,7 +9,7 @@ import Foundation
 import libtesseract
 
 extension Tesseract {
-  @_functionBuilder
+  @resultBuilder
   public struct ConfigurationBuilder {
     public static func buildBlock(_ configurations: (TessBaseAPI) -> Void...) -> (TessBaseAPI) -> Void {
       return { tessPointer in


### PR DESCRIPTION
### Checklist
- [x] I've run the tests to ensure I have not created any regressions
- [x] I've added new tests for new functionality if neccessary. (not needed)
- [x] I've updated the documentation if necessary. (not needed)
- [x] I've read the [Contribution Guidelines](https://github.com/SwiftyTesseract/SwiftyTesseract/blob/develop/CONTRIBUTING.md)

### Motivation and Context
This fixes a deprecation warning when compiling with Swift 5.4.

### Description
Function builders have officially been renamed to result builders, this PR updates this.

### Testing Steps
Nothing unusual, apart from `swift build` and `swift test`.